### PR TITLE
Add `job` labels to alerts that discard it

### DIFF
--- a/charts/cassandra-alerts/templates/alert.yaml
+++ b/charts/cassandra-alerts/templates/alert.yaml
@@ -26,6 +26,7 @@ spec:
       expr: (count(up{job="{{ $app }}-stats",namespace="{{ $.Release.Namespace }}"} == 0) OR vector(0) ) > {{.rules.cassandraDown.val}}
       for: {{ .rules.cassandraDown.duration }}
       labels:
+        job: {{ $app }}-stats
         severity: {{ .rules.cassandraDown.severity }}
         {{- include "cassandra-alerts.alertLabels" $ | nindent 8 }}
       annotations:

--- a/charts/connect-cluster-alerts/templates/alert.yaml
+++ b/charts/connect-cluster-alerts/templates/alert.yaml
@@ -26,6 +26,7 @@ spec:
       expr: count(kafka_connect_worker_connector_count{service="{{ $app }}-stats",namespace="{{ $.Release.Namespace }}"}) == 0
       for: {{ .rules.connectClusterWorkerDown.duration }}
       labels:
+        job: {{ $app }}-stats
         severity: {{ .rules.connectClusterWorkerDown.severity }}
         {{- include "connectcluster-alerts.alertLabels" $ | nindent 8 }}
       annotations:

--- a/charts/kafka-alerts/templates/alert.yaml
+++ b/charts/kafka-alerts/templates/alert.yaml
@@ -103,6 +103,7 @@ spec:
       expr: count(kafka_server_kafkaserver_brokerstate{job="{{ $app }}-stats",namespace="{{ $.Release.Namespace }}"}) == {{ .rules.kafkaBrokerCount.val }}
       for: {{ .rules.kafkaBrokerCount.duration }}
       labels:
+        job: {{ $app }}-stats
         severity: {{ .rules.kafkaBrokerCount.severity }}
         {{- include "kafka-alerts.alertLabels" $ | nindent 8 }}
       annotations:
@@ -147,6 +148,7 @@ spec:
       expr: count(count(kafka_server_brokertopicmetrics_messagesin_total{job="{{ $app }}-stats",namespace="{{ $.Release.Namespace }}"}) by (topic,service)) by (service) > {{ .rules.kafkaTopicCount.val }}
       for: {{ .rules.kafkaTopicCount.duration }}
       labels:
+        job: {{ $app }}-stats
         severity: {{ .rules.kafkaTopicCount.severity }}
         {{- include "kafka-alerts.alertLabels" $ | nindent 8 }}
       annotations:

--- a/charts/postgres-alerts/templates/alert.yaml
+++ b/charts/postgres-alerts/templates/alert.yaml
@@ -37,6 +37,7 @@ spec:
       expr: count(pg_replication_is_replica{job="{{- $app -}}-stats",namespace="{{ $.Release.Namespace }}"} == 0) != 1
       for: {{ .rules.postgresSplitBrain.duration }}
       labels:
+        job: {{ $app }}-stats
         severity: {{ .rules.postgresSplitBrain.severity }}
         {{- include "postgres-alerts.alertLabels" $ | nindent 8 }}
       annotations:

--- a/charts/redis-alerts/templates/alert.yaml
+++ b/charts/redis-alerts/templates/alert.yaml
@@ -37,11 +37,12 @@ spec:
       expr: (count(redis_instance_info{job="{{- $app -}}-stats",namespace="{{ $.Release.Namespace }}"}) or vector(0)) < {{.rules.redisMissingMaster.val}}
       for: {{ .rules.redisMissingMaster.duration }}
       labels:
+        job: {{ $app }}-stats
         severity: {{ .rules.redisMissingMaster.severity }}
         {{- include "redis-alerts.alertLabels" $ | nindent 8 }}
       annotations:
-        summary: Redis missing master (instance {{`{{`}} $labels.pod {{`}}`}})
-        description: "Redis cluster has less than expected amount of node marked as master\n  VALUE = {{`{{`}} $value {{`}}`}}\n  LABELS = {{`{{`}} $labels {{`}}`}}"
+        summary: Redis missing master (component {{`{{`}} $labels.job {{`}}`}})
+        description: "Redis cluster has less than expected amount of nodes marked as master for {{`{{`}} $labels.job {{`}}`}}.\n  VALUE = {{`{{`}} $value {{`}}`}}\n  LABELS = {{`{{`}} $labels {{`}}`}}"
     {{end -}}
     {{ if (include "redis-alerts.alertEnabled" (list $.Values.form.alert.enabled .enabled .rules.redisTooManyConnections.enabled .rules.redisTooManyConnections.severity)) -}}
     - alert: RedisTooManyConnections
@@ -59,11 +60,12 @@ spec:
       expr: (count(redis_instance_info{job="{{- $app -}}-stats",namespace="{{ $.Release.Namespace }}"})) > {{.rules.redisTooManyMasters.val}}
       for: {{ .rules.redisTooManyMasters.duration }}
       labels:
+        job: {{ $app }}-stats
         severity: {{ .rules.redisTooManyMasters.severity }}
         {{- include "redis-alerts.alertLabels" $ | nindent 8 }}
       annotations:
-        summary: Redis too many master nodes (instance {{`{{`}} $labels.pod {{`}}`}})
-        description: "Redis cluster has too many nodes marked as master. \n  VALUE = {{`{{`}} $value {{`}}`}}\n  LABELS = {{`{{`}} $labels {{`}}`}}"
+        summary: Redis too many master nodes (component {{`{{`}} $labels.job {{`}}`}})
+        description: "Redis cluster has too many nodes marked as master for {{`{{`}} $labels.job {{`}}`}}.\n  VALUE = {{`{{`}} $value {{`}}`}}\n  LABELS = {{`{{`}} $labels {{`}}`}}"
     {{ end -}}
     {{ if (include "redis-alerts.alertEnabled" (list $.Values.form.alert.enabled .enabled .rules.redisDisconnectedSlaves.enabled .rules.redisDisconnectedSlaves.severity)) -}}
     - alert: RedisDisconnectedSlaves

--- a/charts/solr-alerts/templates/alert.yaml
+++ b/charts/solr-alerts/templates/alert.yaml
@@ -26,6 +26,7 @@ spec:
       expr: count(max by (core) (solr_collections_replica_state{namespace="{{ $.Release.Namespace }}",job="{{ $app }}-stats",state="down"})) OR on() vector(0) != 0
       for: {{ .rules.solrDownShards.duration }}
       labels:
+        job: {{ $app }}-stats
         severity: {{ .rules.solrDownShards.severity }}
         {{- include "solr-alerts.alertLabels" $ | nindent 8 }}
       annotations:
@@ -37,6 +38,7 @@ spec:
       expr: count(max by (core) (solr_collections_replica_state{namespace="{{ $.Release.Namespace }}",job="{{ $app }}-stats",state="recovery_failed"})) OR on() vector(0) != 0
       for: {{ .rules.solrRecoveryFailedShards.duration }}
       labels:
+        job: {{ $app }}-stats
         severity: {{ .rules.solrRecoveryFailedShards.severity }}
         {{- include "solr-alerts.alertLabels" $ | nindent 8 }}
       annotations:
@@ -155,5 +157,4 @@ spec:
   {{ end -}}
 
 {{ end }}
-
 


### PR DESCRIPTION
This label is used to identify the source of the metrics that the alert(s) triggered on

<img width="1542" height="432" alt="image" src="https://github.com/user-attachments/assets/e3f24cc9-385b-41f4-a086-0e02a1702b38" />


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/opnpulse/codesmith/alerts/pr/130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784371967&installation_id=126731068&pr_number=130&repository=opnpulse%2Falerts&return_to=https%3A%2F%2Fgithub.com%2Fopnpulse%2Falerts%2Fpull%2F130&signature=5fd3d286f99a4d874ca7ea8b64c3ff1c806330d5114495eddc534d4aaf69a398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->