### PR TITLE
Exclude pg_dump sessions from PostgresqlSlowQueries alert

### DIFF
--- a/charts/postgres-alerts/templates/alert.yaml
+++ b/charts/postgres-alerts/templates/alert.yaml
@@ -139,7 +139,7 @@ spec:
     {{- end }}
     {{ if (include "postgres-alerts.alertEnabled" (list $.Values.form.alert.enabled .enabled .rules.postgresSlowQueries.enabled .rules.postgresSlowQueries.severity)) -}}
     - alert: PostgresqlSlowQueries
-      expr: pg_stat_activity_max_tx_duration{job="{{- $app -}}-stats",namespace="{{ $.Release.Namespace }}",state="active"} > {{ .rules.postgresSlowQueries.val }}
+      expr: pg_stat_activity_max_tx_duration{job="{{- $app -}}-stats",namespace="{{ $.Release.Namespace }}",state="active",application_name!~"pg_dump.*"} > {{ .rules.postgresSlowQueries.val }}
       for: {{ .rules.postgresSlowQueries.duration }}
       labels:
         severity: {{ .rules.postgresSlowQueries.severity }}


### PR DESCRIPTION
## Problem

`PostgresqlSlowQueries` fires on every `pg_dump` backup:

```
PostgreSQL has a transaction running longer than 60s on ace-db-2.
  VALUE = 136.308345
  LABELS = map[__name__:pg_stat_activity_max_tx_duration application_name:pg_dump backend_type:client backend container:exporter datname:ace endpoint:metrics instance:10.2.4.8:56790 job:ace-db-stats namespace:ace pod:ace-db-2 server:localhost:5432 service:ace-db-stats state:active usename:postgres]
```

`pg_dump` holds a single repeatable-read transaction open for the entire duration of the dump to get a consistent snapshot, so `pg_stat_activity_max_tx_duration` for that session grows to however long the backup takes. That is expected behaviour for a backup, not a slow query, so the alert is pure noise on any database large enough for a dump to exceed the threshold.

## Change

Add `application_name!~"pg_dump.*"` to the alert expression in `charts/postgres-alerts/templates/alert.yaml`, which drops both `pg_dump` and `pg_dumpall` sessions. Client workloads that are genuinely slow still trigger the alert unchanged.

Rendered output:

```
- alert: PostgresqlSlowQueries
  expr: pg_stat_activity_max_tx_duration{job="test-stats",namespace="ace",state="active",application_name!~"pg_dump.*"} > 60
```

Verified with `helm template`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/opnpulse/codesmith/alerts/pr/139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789280433&installation_model_id=19678&pr_number=139&repository=opnpulse%2Falerts&return_to=https%3A%2F%2Fgithub.com%2Fopnpulse%2Falerts%2Fpull%2F139&signature=2cb218426db6d726c1775da61726efd66bdba50639bb462f88783773880d976a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->